### PR TITLE
Add MODEL config for custom models

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Available keys:
 - `LOCALE` (default: `en`): One of `en, es, pt, fr, de, it, ja, ko, zh`
 - `MAX_RETRIES` (default: `2`): Non-negative integer
 - `TIMEOUT` (default: `10000`): Milliseconds
+- `MODEL` (default: `openai/gpt-oss-20b`): AI model to use for generating PR content.
 
 Examples:
 
@@ -90,6 +91,7 @@ Examples:
 lazypr config set LOCALE=es
 lazypr config set MAX_RETRIES=3
 lazypr config set TIMEOUT=15000
+lazypr config set MODEL=openai/gpt-oss-120b
 ```
 
 ## How it works 🧠

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -56,6 +56,30 @@ export const CONFIG_SCHEMA = {
       return branch;
     },
   },
+  MODEL: {
+    default: "openai/gpt-oss-20b",
+    validate: (v: string) => {
+      const model = v?.trim();
+      if (!model) throw new Error("MODEL cannot be empty");
+
+      // Only allow models that support structured outputs
+      const supportedModels = [
+        "openai/gpt-oss-20b",
+        "openai/gpt-oss-120b",
+        "moonshotai/kimi-k2-instruct-0905",
+        "meta-llama/llama-4-maverick-17b-128e-instruct",
+        "meta-llama/llama-4-scout-17b-16e-instruct",
+      ];
+
+      if (!supportedModels.includes(model)) {
+        throw new Error(
+          `MODEL must be one of the supported structured output models: ${supportedModels.join(", ")}`,
+        );
+      }
+
+      return model;
+    },
+  },
 } as const satisfies Record<string, ConfigSchemaValue>;
 
 export type ConfigKey = keyof typeof CONFIG_SCHEMA;

--- a/utils/groq.ts
+++ b/utils/groq.ts
@@ -12,16 +12,17 @@ const pullRequestSchema = z.object({
 
 export async function generatePullRequest(
   currentBranch: string,
-  commits: GitCommit[]
+  commits: GitCommit[],
 ) {
   const groq = createGroq({
     apiKey: await config.get("GROQ_API_KEY"),
   });
   const locale = await config.get("LOCALE");
+  const model = await config.get("MODEL");
   const commitsString = commits.map((commit) => commit.message).join("\n");
 
   const { object } = await generateObject({
-    model: groq("openai/gpt-oss-20b"),
+    model: groq(model),
     schema: pullRequestSchema,
     maxRetries: parseInt(await config.get("MAX_RETRIES")),
     abortSignal: AbortSignal.timeout(parseInt(await config.get("TIMEOUT"))),
@@ -30,13 +31,13 @@ export async function generatePullRequest(
 
     - The target branch name (e.g. \`feature/login\`, \`bugfix/auth-token\`) is a strong indicator of the overall intent.
     - Use the commit messages (provided in the user prompt) as concrete evidence of what changed.
-    - **ALL output (title and description) MUST be written in the language identified by the locale**  
+    - **ALL output (title and description) MUST be written in the language identified by the locale**
       If the requested language is not supported, fall back to English.
     - Title requirements:
-      - 5-50 characters  
+      - 5-50 characters
       - Written in imperative mood, start with a capital letter, no trailing period
     - Description requirements:
-      - At least 20 characters  
+      - At least 20 characters
       - Use markdown formatting, be concise yet informative
     - Keep the tone professional.
     `,


### PR DESCRIPTION
Adds a `MODEL` configuration option with validation and an example usage for custom models.

- New `MODEL` config is now validated.
- Example provided in the docs.