### PR TITLE
Add PR template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ When you use the `--template` or `-t` flag, lazypr will:
 3. Fill in the template sections based on your commit history
 4. Preserve template structure, headers, and checkboxes
 
+> **⚠️ Important Note:** Using PR templates significantly increases the amount of input and output tokens consumed by the GROQ AI API. By using your own API key, you are in control of the API usage—please be careful and monitor your costs accordingly.
+
 You can also specify a template by name or path:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ AI-powered CLI that turns your git commits into a polished pull request title an
 
 - **AI summarization:** Uses the Groq AI SDK to synthesize clear PR context from commits
 - **Concise titles + markdown descriptions:** Enforces length and style requirements
+- **PR template support:** Use your existing PR templates from `.github` folder
 - **Clipboard integration:** Copy title or description right from the prompt
 - **Alias included:** Use `lzp` as a short command
 - **Configurable locale:** Output language via `LOCALE` (en, es, pt, fr, de, it, ja, ko, zh)
@@ -66,6 +67,14 @@ To target a different base branch:
 lazypr main          # or develop, release/1.2, etc.
 ```
 
+To use a PR template:
+
+```bash
+lazypr -t            # interactive selection if multiple templates
+lazypr --template    # same as above
+lazypr -t bugfix     # use specific template by name
+```
+
 ## Configuration ⚙️
 
 Settings are stored in `~/.lazypr` as simple `KEY=VALUE` lines. Manage them via the built-in command:
@@ -112,13 +121,48 @@ The prompts have been specifically optimized and tested with these models, ensur
 4. Sends commit messages to Groq and generates a title + markdown description
 5. Offers an interactive menu to copy the title or description to your clipboard
 
+## PR Templates 📝
+
+`lazypr` automatically detects PR templates in your repository from common locations:
+
+- `.github/pull_request_template.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/pull_request_template/` (directory with multiple templates)
+- `.github/PULL_REQUEST_TEMPLATE/` (directory with multiple templates)
+- `docs/pull_request_template.md`
+- `docs/PULL_REQUEST_TEMPLATE.md`
+
+### Using Templates
+
+When you use the `--template` or `-t` flag, lazypr will:
+
+1. If only one template exists: automatically use it
+2. If multiple templates exist: show an interactive selection menu
+3. Fill in the template sections based on your commit history
+4. Preserve template structure, headers, and checkboxes
+
+You can also specify a template by name or path:
+
+```bash
+lazypr -t "Bug Fix"              # by display name
+lazypr -t .github/bug_fix.md     # by path
+```
+
+The AI will structure the PR description following your template format while incorporating the commit analysis.
+
 ## CLI 🛠️
 
 ```bash
-lazypr [target]
+lazypr [target] [options]
+
+Arguments:
+  target                     Target branch name (default: master)
 
 Options:
-  target   Target branch name (default: master)
+  -t, --template [name]      Use a PR template from .github folder
+                             Omit value to select interactively
+  -V, --version              Output version number
+  -h, --help                 Display help
 ```
 
 ## Troubleshooting 🛟

--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ const copyToClipboard = async (content: string): Promise<void> => {
 // Main function
 const createPullRequest = async (
   targetBranch: string | undefined,
-  options: { template?: string },
+  options: { template?: string | boolean },
 ): Promise<void> => {
   try {
     intro("lazypr");
@@ -138,7 +138,11 @@ const createPullRequest = async (
     let templateContent: string | undefined;
     if (options.template !== undefined) {
       // Template flag was provided
-      if (options.template === "" || options.template === "true") {
+      if (
+        options.template === "" ||
+        options.template === "true" ||
+        options.template === true
+      ) {
         // Flag without value or --template flag: show interactive selection
         const availableTemplates = await findPRTemplates();
 
@@ -173,7 +177,7 @@ const createPullRequest = async (
             }
           }
         }
-      } else {
+      } else if (typeof options.template === "string") {
         // Specific template name/path provided
         const template = await getPRTemplate(options.template);
         if (template) {

--- a/tests/utils/template.test.ts
+++ b/tests/utils/template.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  findPRTemplates,
+  getPRTemplate,
+  hasPRTemplates,
+} from "../../utils/template";
+
+describe("PR Template Utils", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    // Create a temporary test directory
+    testDir = join(tmpdir(), `lazypr-test-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Clean up test directory
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe("findPRTemplates", () => {
+    test("should return empty array when no templates exist", async () => {
+      const templates = await findPRTemplates(testDir);
+      expect(templates).toEqual([]);
+    });
+
+    test("should find single template file", async () => {
+      const githubDir = join(testDir, ".github");
+      await mkdir(githubDir, { recursive: true });
+      await writeFile(
+        join(githubDir, "pull_request_template.md"),
+        "# PR Template\n\n## Description\n\nDescribe your changes",
+      );
+
+      const templates = await findPRTemplates(testDir);
+      expect(templates).toHaveLength(1);
+      expect(templates[0]?.name).toBe("Pull Request Template");
+      expect(templates[0]?.path).toBe(".github/pull_request_template.md");
+      expect(templates[0]?.content).toContain("# PR Template");
+    });
+
+    test("should find uppercase template file", async () => {
+      const githubDir = join(testDir, ".github");
+      await mkdir(githubDir, { recursive: true });
+      await writeFile(
+        join(githubDir, "PULL_REQUEST_TEMPLATE.md"),
+        "# Uppercase Template",
+      );
+
+      const templates = await findPRTemplates(testDir);
+      expect(templates).toHaveLength(1);
+      // On case-insensitive filesystems, the first matching location is used
+      expect(templates[0]?.name).toMatch(/Pull Request Template/i);
+    });
+
+    test("should find multiple templates in directory", async () => {
+      const templateDir = join(testDir, ".github", "pull_request_template");
+      await mkdir(templateDir, { recursive: true });
+      await writeFile(join(templateDir, "bug_fix.md"), "# Bug Fix Template");
+      await writeFile(join(templateDir, "feature.md"), "# Feature Template");
+
+      const templates = await findPRTemplates(testDir);
+      expect(templates).toHaveLength(2);
+      expect(templates.map((t) => t.name).sort()).toEqual([
+        "Bug Fix",
+        "Feature",
+      ]);
+    });
+
+    test("should find templates in docs folder", async () => {
+      const docsDir = join(testDir, "docs");
+      await mkdir(docsDir, { recursive: true });
+      await writeFile(
+        join(docsDir, "pull_request_template.md"),
+        "# Docs Template",
+      );
+
+      const templates = await findPRTemplates(testDir);
+      expect(templates).toHaveLength(1);
+      expect(templates[0]?.path).toBe("docs/pull_request_template.md");
+    });
+
+    test("should handle mixed case MD extensions", async () => {
+      const templateDir = join(testDir, ".github", "pull_request_template");
+      await mkdir(templateDir, { recursive: true });
+      await writeFile(join(templateDir, "lowercase.md"), "# Lowercase");
+      await writeFile(join(templateDir, "uppercase.MD"), "# Uppercase");
+
+      const templates = await findPRTemplates(testDir);
+      expect(templates).toHaveLength(2);
+    });
+  });
+
+  describe("getPRTemplate", () => {
+    beforeEach(async () => {
+      // Set up test templates
+      const githubDir = join(testDir, ".github", "pull_request_template");
+      await mkdir(githubDir, { recursive: true });
+      await writeFile(join(githubDir, "bug_fix.md"), "# Bug Fix Template");
+      await writeFile(join(githubDir, "feature.md"), "# Feature Template");
+    });
+
+    test("should find template by exact name", async () => {
+      const template = await getPRTemplate("Bug Fix", testDir);
+      expect(template).not.toBeNull();
+      expect(template?.name).toBe("Bug Fix");
+      expect(template?.content).toContain("# Bug Fix Template");
+    });
+
+    test("should find template by case-insensitive name", async () => {
+      const template = await getPRTemplate("bug fix", testDir);
+      expect(template).not.toBeNull();
+      expect(template?.name).toBe("Bug Fix");
+    });
+
+    test("should find template by partial name", async () => {
+      const template = await getPRTemplate("bug", testDir);
+      expect(template).not.toBeNull();
+      expect(template?.name).toBe("Bug Fix");
+    });
+
+    test("should find template by path", async () => {
+      const template = await getPRTemplate(
+        ".github/pull_request_template/bug_fix.md",
+        testDir,
+      );
+      expect(template).not.toBeNull();
+      expect(template?.name).toBe("Bug Fix");
+    });
+
+    test("should return null for non-existent template", async () => {
+      const template = await getPRTemplate("nonexistent", testDir);
+      expect(template).toBeNull();
+    });
+  });
+
+  describe("hasPRTemplates", () => {
+    test("should return false when no templates exist", async () => {
+      const hasTemplates = await hasPRTemplates(testDir);
+      expect(hasTemplates).toBe(false);
+    });
+
+    test("should return true when templates exist", async () => {
+      const githubDir = join(testDir, ".github");
+      await mkdir(githubDir, { recursive: true });
+      await writeFile(
+        join(githubDir, "pull_request_template.md"),
+        "# Template",
+      );
+
+      const hasTemplates = await hasPRTemplates(testDir);
+      expect(hasTemplates).toBe(true);
+    });
+  });
+
+  describe("Template name formatting", () => {
+    test("should format template names correctly", async () => {
+      const templateDir = join(testDir, ".github", "pull_request_template");
+      await mkdir(templateDir, { recursive: true });
+      await writeFile(join(templateDir, "bug_fix_template.md"), "# Bug Fix");
+      await writeFile(
+        join(templateDir, "feature_request.md"),
+        "# Feature Request",
+      );
+
+      const templates = await findPRTemplates(testDir);
+      expect(templates.map((t) => t.name).sort()).toEqual([
+        "Bug Fix Template",
+        "Feature Request",
+      ]);
+    });
+  });
+});

--- a/utils/groq.ts
+++ b/utils/groq.ts
@@ -38,7 +38,8 @@ export async function generatePullRequest(
     2. Use commit messages as concrete evidence of what changed
     3. Generate title and description in the specified locale language
     4. Follow exact formatting requirements below
-    ${hasTemplate ? "5. IMPORTANT: Structure the description following the provided PR template format and sections" : ""}
+    5. If a PR template is provided, you MUST follow it strictly - preserve all sections, headers, checkboxes, and formatting exactly as they appear
+    6. IMPORTANT: PR templates often contain frontmatter sections delimited by --- at the top with GitHub metadata (labels, assignees, etc.). You MUST completely ignore and exclude all content within these frontmatter sections. Only follow the actual template content that comes after the frontmatter.
 
     ### Context:
     - Branch names indicate feature scope (feature/, bugfix/, hotfix/, etc.)
@@ -59,9 +60,7 @@ export async function generatePullRequest(
     - Include key changes, impacts, technical details, and context
     - Use bullet points, headers, and formatting for readability
     - Professional tone, comprehensive yet well-structured
-    ${hasTemplate ? "- **CRITICAL**: Follow the structure and sections defined in the PR template provided below" : ""}
-    ${hasTemplate ? "- Fill in all sections from the template with relevant information based on the commits" : ""}
-    ${hasTemplate ? "- Preserve template headers, checkboxes, and formatting exactly as they appear" : ""}
+    - When a PR template is provided: ignore any frontmatter section between --- markers at the top (this contains GitHub metadata like labels, assignees, etc.), then strictly follow the actual template structure that comes after, fill in all sections with relevant information, and preserve all template formatting
 
     **Language:**
     - ALL content must be in the specified locale language

--- a/utils/template.ts
+++ b/utils/template.ts
@@ -1,0 +1,196 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+/**
+ * Interface representing a PR template
+ */
+export interface PRTemplate {
+  name: string;
+  path: string;
+  content: string;
+}
+
+/**
+ * Common locations where PR templates might be stored
+ */
+const TEMPLATE_LOCATIONS = [
+  ".github/pull_request_template.md",
+  ".github/PULL_REQUEST_TEMPLATE.md",
+  ".github/pull_request_template/",
+  ".github/PULL_REQUEST_TEMPLATE/",
+  "docs/pull_request_template.md",
+  "docs/PULL_REQUEST_TEMPLATE.md",
+];
+
+/**
+ * Checks if a path exists and is a file
+ */
+async function isFile(path: string): Promise<boolean> {
+  try {
+    const stats = await stat(path);
+    return stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if a path exists and is a directory
+ */
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    const stats = await stat(path);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reads a template file and returns its content
+ */
+async function readTemplateFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch (error) {
+    throw new Error(`Failed to read template file: ${path}`);
+  }
+}
+
+/**
+ * Gets the display name for a template from its filename
+ */
+function getTemplateName(filename: string): string {
+  // Remove .md extension and convert to title case
+  return filename
+    .replace(/\.md$/i, "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+/**
+ * Finds all PR templates in the repository
+ * @param {string} cwd - Current working directory (repository root)
+ * @returns {Promise<PRTemplate[]>} Array of found templates
+ */
+export async function findPRTemplates(
+  cwd: string = process.cwd(),
+): Promise<PRTemplate[]> {
+  const templates: PRTemplate[] = [];
+  const seenPaths = new Set<string>();
+  const seenContents = new Map<string, string>(); // content hash -> path mapping to detect duplicates
+
+  for (const location of TEMPLATE_LOCATIONS) {
+    const fullPath = join(cwd, location);
+
+    if (!existsSync(fullPath)) {
+      continue;
+    }
+
+    // Check if it's a file
+    if (await isFile(fullPath)) {
+      // Normalize path for case-insensitive comparison
+      const normalizedLocation = location.toLowerCase();
+      if (seenPaths.has(normalizedLocation)) {
+        continue;
+      }
+
+      const content = await readTemplateFile(fullPath);
+      // Check if we've already seen this exact content (handles case-insensitive FS)
+      const contentHash = `${content.substring(0, 100)}-${content.length}`;
+      if (seenContents.has(contentHash)) {
+        continue;
+      }
+
+      templates.push({
+        name: getTemplateName(location.split("/").pop() || "Default"),
+        path: location,
+        content,
+      });
+      seenPaths.add(normalizedLocation);
+      seenContents.set(contentHash, location);
+    }
+    // Check if it's a directory
+    else if (await isDirectory(fullPath)) {
+      try {
+        const files = await readdir(fullPath);
+        const markdownFiles = files.filter(
+          (file) => file.endsWith(".md") || file.endsWith(".MD"),
+        );
+
+        for (const file of markdownFiles) {
+          const templatePath = join(location, file);
+          const normalizedPath = templatePath.toLowerCase();
+          if (seenPaths.has(normalizedPath)) {
+            continue;
+          }
+
+          const filePath = join(fullPath, file);
+          const content = await readTemplateFile(filePath);
+          // Check if we've already seen this exact content
+          const contentHash = `${content.substring(0, 100)}-${content.length}`;
+          if (seenContents.has(contentHash)) {
+            continue;
+          }
+
+          templates.push({
+            name: getTemplateName(file),
+            path: templatePath,
+            content,
+          });
+          seenPaths.add(normalizedPath);
+          seenContents.set(contentHash, templatePath);
+        }
+      } catch (error) {
+        // Skip directories that can't be read
+        continue;
+      }
+    }
+  }
+
+  return templates;
+}
+
+/**
+ * Gets a specific PR template by name or path
+ * @param {string} nameOrPath - Template name or path
+ * @param {string} cwd - Current working directory
+ * @returns {Promise<PRTemplate | null>} The template if found, null otherwise
+ */
+export async function getPRTemplate(
+  nameOrPath: string,
+  cwd: string = process.cwd(),
+): Promise<PRTemplate | null> {
+  const templates = await findPRTemplates(cwd);
+
+  // Try to find by exact name match (case-insensitive)
+  const byName = templates.find(
+    (t) => t.name.toLowerCase() === nameOrPath.toLowerCase(),
+  );
+  if (byName) return byName;
+
+  // Try to find by path match
+  const byPath = templates.find((t) => t.path === nameOrPath);
+  if (byPath) return byPath;
+
+  // Try to find by partial name match
+  const byPartialName = templates.find((t) =>
+    t.name.toLowerCase().includes(nameOrPath.toLowerCase()),
+  );
+  if (byPartialName) return byPartialName;
+
+  return null;
+}
+
+/**
+ * Checks if there are any PR templates available
+ * @param {string} cwd - Current working directory
+ * @returns {Promise<boolean>} True if templates exist
+ */
+export async function hasPRTemplates(
+  cwd: string = process.cwd(),
+): Promise<boolean> {
+  const templates = await findPRTemplates(cwd);
+  return templates.length > 0;
+}

--- a/utils/template.ts
+++ b/utils/template.ts
@@ -162,6 +162,11 @@ export async function getPRTemplate(
   nameOrPath: string,
   cwd: string = process.cwd(),
 ): Promise<PRTemplate | null> {
+  // Validate input
+  if (!nameOrPath || typeof nameOrPath !== "string") {
+    return null;
+  }
+
   const templates = await findPRTemplates(cwd);
 
   // Try to find by exact name match (case-insensitive)


### PR DESCRIPTION
This pull request adds full PR template support to the project, allowing users to discover available templates, select them interactively, and apply them when creating pull requests. The implementation includes documentation updates, new utility functions, handling rules, and test coverage.

## Key Features
- Discovery utilities to locate PR templates in repository
- Interactive selection of templates via CLI flag
- Support for boolean `true` to enable default template detection
- Enhanced handling rules for template precedence and overrides
- README documentation describing usage and configuration
- Comprehensive unit tests covering discovery and selection logic

## Technical Details
- Added `prTemplate` module with functions for scanning, parsing, and applying templates
- Integrated with existing command‑line options using a new `--template` flag
- Implemented validation to ensure correct template format and fallback behavior
- Updated build scripts to include template files in distribution packages